### PR TITLE
add LOGZIO_TYPE env var to match docker-collector-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ logzio/docker-collector-metrics
 ### 3. Check Logz.io for your metrics
 
 Spin up your Docker containers if you haven’t done so already. Give your metrics a few minutes to get from your system to ours, and then open [Kibana](https://app.logz.io/#/dashboard/kibana).
+
+## Change log
+ - **v0.0.2**: added the ability to set the type to fetched metrics.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ logzio/docker-collector-metrics
 |---|---|
 | **LOGZIO_TOKEN** | **Required**. Your Logz.io account token. Replace `<ACCOUNT-TOKEN>` with the [token](https://app.logz.io/#/dashboard/settings/general) of the account you want to ship to. |
 | **LOGZIO_URL** | **Required**. Logz.io listener URL to ship the metrics to. This URL changes depending on the region your account is hosted in. For example, accounts in the US region ship to `listener.logz.io`, and accounts in the EU region ship to `listener-eu.logz.io`. <br /> For more information, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html) on the Logz.io Docs. |
+| **LOGZIO_TYPE** | Logz.io type. Metrics fetched by this docker will have this type. <br /> **Default**: docker-collector-metrics |
 | **matchContainerName** | Comma-separated list of containers you want to collect metrics from. If a container's name partially matches a name on the list, that container's metrics are shipped. Otherwise, its metrics are ignored. <br /> **Note**: Can't be used with `skipContainerName` |
 | **skipContainerName** | Comma-separated list of containers you want to ignore. If a container's name partially matches a name on the list, that container's metrics are ignored. Otherwise, its metrics are shipped. <br /> **Note**: Can't be used with `matchContainerName` |
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ logzio/docker-collector-metrics
 |---|---|
 | **LOGZIO_TOKEN** | **Required**. Your Logz.io account token. Replace `<ACCOUNT-TOKEN>` with the [token](https://app.logz.io/#/dashboard/settings/general) of the account you want to ship to. |
 | **LOGZIO_URL** | **Required**. Logz.io listener URL to ship the metrics to. This URL changes depending on the region your account is hosted in. For example, accounts in the US region ship to `listener.logz.io`, and accounts in the EU region ship to `listener-eu.logz.io`. <br /> For more information, see [Account region](https://docs.logz.io/user-guide/accounts/account-region.html) on the Logz.io Docs. |
-| **LOGZIO_TYPE** | Logz.io type. Metrics fetched by this docker will have this type. <br /> **Default**: docker-collector-metrics |
+| **LOGZIO_TYPE** | **Default**: `docker-collector-metrics` <br /> Logz.io type you'll use with this Docker. This is shown in your logs under the `type` field in Kibana. Logz.io applies parsing based on type. |
 | **matchContainerName** | Comma-separated list of containers you want to collect metrics from. If a container's name partially matches a name on the list, that container's metrics are shipped. Otherwise, its metrics are ignored. <br /> **Note**: Can't be used with `skipContainerName` |
 | **skipContainerName** | Comma-separated list of containers you want to ignore. If a container's name partially matches a name on the list, that container's metrics are ignored. Otherwise, its metrics are shipped. <br /> **Note**: Can't be used with `matchContainerName` |
 

--- a/metricbeat-yml-script.py
+++ b/metricbeat-yml-script.py
@@ -8,6 +8,8 @@ import socket
 logzio_url = os.environ["LOGZIO_URL"]
 logzio_url_arr = logzio_url.split(":")
 logzio_token = os.environ["LOGZIO_TOKEN"]
+logzio_type = os.getenv("LOGZIO_TYPE", "docker-collector-metrics")
+
 docker_sock_path = "unix:///var/run/docker.sock"
 
 HOST = logzio_url_arr[0]
@@ -39,6 +41,7 @@ def _add_shipping_data():
     config_dic["output.logstash"]["hosts"].append(logzio_url)
     config_dic["metricbeat.modules"][0]["hosts"].append(docker_sock_path)
     config_dic["fields"]["token"] = logzio_token
+    config_dic["fields"]["type"] = logzio_type
 
     with open(METRICBEAT_CONF_PATH, "w+") as metricbeat_yml:
         yaml.dump(config_dic, metricbeat_yml)


### PR DESCRIPTION
I use the LOGZIO_TYPE field on my `docker-collector-logs` to sort environments (dev vs stage vs prod).  This field doesn't exist on the `docker-collector-metrics` project, but it's a simple thing to add.

This commit adds the LOGZIO_TYPE environment variable, sets it to a sane default, or uses the provided value in the log output.