### PR TITLE
add note for linux OSes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ You'll need this for your Metricbeat configuration later.
 
 ### System module
 
+**Note**:
+This Docker container monitors Linux system metrics only.
+For other OSes, we recommend running Metricbeat locally on the system itself.
+
 For the system module,
 you'll need to include `system` in the `LOGZIO_MODULES` environment variable.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You'll need this for your Metricbeat configuration later.
 
 **Note**:
 This Docker container monitors Linux system metrics only.
-For other OSes, we recommend running Metricbeat locally on the system itself.
+For other OSes, we recommend [running Metricbeat locally](https://docs.logz.io/shipping/metrics-sources/system.html) on the system itself.
 
 For the system module,
 you'll need to include `system` in the `LOGZIO_MODULES` environment variable.


### PR DESCRIPTION
This PR adds the note that this Docker monitors Linux system metrics; others need to run metricbeat locally.

Syncs the readme with the docs https://github.com/logzio/logz-docs/pull/459