### PR TITLE
hostname & minor change

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ in the [_Modules_](#modules) section at the bottom of this doc.
 | LOGZIO_LOG_LEVEL (Default: `"INFO"`) | The log level the module startup scripts will generate. |
 | LOGZIO_EXTRA_DIMENSIONS | Semicolon-separated list of dimensions to be included with your metrics (formatted as `dimensionName1=value1;dimensionName2=value2`). <br> To use an environment variable as a value, format as `dimensionName=$ENV_VAR_NAME`. Environment variables must be the only value in the field. If an environment variable can't be resolved, the field is omitted. |
 | DEBUG (Default: `false`) | Set to `true` if you want Metricbeat to run in debug mode.<br/> **Note:** Debug mode tends to generate a lot of debugging output, so you should probably enable it temporarily only when an error occurs while running the docker-collector in production.  |
+| HOSTNAME (Default: `''`) | Insert your host name if you want it to appear in the metrics' `host.name`. If no value entered,  `host.name` will show the container's id. |
 
 ### 3. Check Logz.io for your metrics
 
@@ -165,6 +166,8 @@ logzio/docker-collector-metrics
 ```
 
 ## Change log
+ - **0.1.5**:
+    - Supports adding hostname.
  - **0.1.4**:
     - Supporting debug mode.
  - **0.1.3**:

--- a/metricbeat-yml-script.py
+++ b/metricbeat-yml-script.py
@@ -107,6 +107,10 @@ def _add_shipping_data():
     conf["fields"]["type"] = os.getenv("LOGZIO_TYPE", "docker-collector-metrics")
 
     additional_field = _get_additional_fields()
+
+    hostname = _get_host_name()
+    if hostname is not '':
+        conf["name"] = hostname
     if len(additional_field) > 0:
         conf["fields"]["dim"] = {}
     for key in additional_field:
@@ -150,7 +154,8 @@ def parse_entry(entry):
 
 def _add_data_by_module(modules):
     for module in modules:
-        if module.lower() == "aws":
+        module_name = module.lower()
+        if module_name == "aws":
             _add_aws_shipping_data()
 
 
@@ -181,8 +186,9 @@ def _add_aws_shipping_data():
 
 
 def _get_tags_value(aws_namespace):
-    if "aws/" in aws_namespace.lower():
-        service_name = aws_namespace.split("/")[1].lower()
+    aws_namespace_lower = aws_namespace.lower()
+    if "aws/" in aws_namespace_lower:
+        service_name = aws_namespace_lower.split("/")[1]
         if service_name == "ebs":
             return "ec2:snapshot"
         elif service_name == "elb" or service_name == "applicationelb" or service_name == "networkelb":
@@ -194,7 +200,7 @@ def _get_tags_value(aws_namespace):
         else:
             return service_name
     else:
-        return aws_namespace.lower()
+        return aws_namespace_lower
 
 
 def _get_aws_namespaces():
@@ -222,6 +228,10 @@ def _get_debug_mode():
         return '-d "*"'
     else:
         return ""
+
+
+def _get_host_name():
+    return os.getenv("HOSTNAME", '')
 
 
 logger = _create_logger()


### PR DESCRIPTION
* Added the ability to add hostname to appear under `host.name`. If not specified, it will remain as it is now (host.name = container id).
* Minor change in `_get_tags_value` function. Now it's using .lower() only one time.
=====
@shalper - In the readme i've added to the `Parameters for all modules` table new entry - HOSTNAME. Can you please review the description, and add it to our docs?