### PR TITLE
Optimize dockerfile to reduce image size

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -6,9 +6,9 @@ ENV LOGZIO_DIR_PATH /logzio
 ENV LOGZIO_MODULES_PATH ${LOGZIO_DIR_PATH}/modules
 
 
-RUN apt-get update && \
-    apt-get install -y curl wget && \
-    curl -L -O https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-7.10.0-amd64.deb && \
+RUN apt-get update && apt-get install --no-install-recommends -y wget && \
+    rm -rf /var/lib/apt/lists/* && \ 
+    wget --quiet https://artifacts.elastic.co/downloads/beats/metricbeat/metricbeat-7.10.0-amd64.deb && \
     dpkg -i metricbeat-7.10.0-amd64.deb && \
     rm metricbeat-7.10.0-amd64.deb && \
     wget https://raw.githubusercontent.com/logzio/public-certificates/master/TrustExternalCARoot_and_USERTrustRSAAAACA.crt && \


### PR DESCRIPTION
Following optimizations result in ~22MB docker image size reduction:
* apt-get install with "--no-install-recommends" to only install main dependencies
* removing /var/lib/apt/lists/* as not needed after anymore after apt package installs
* curl and wget in this case seem to serve the same purpose, hence suggesting to optimized and use only one (wget)